### PR TITLE
add option to suppress pylint report if score is below limit

### DIFF
--- a/git-pylint-commit-hook
+++ b/git-pylint-commit-hook
@@ -45,6 +45,10 @@ def main():
         '--pylint-params',
         help='Custom pylint parameters to add to the pylint command')
     parser.add_argument(
+        '--suppress-report',
+        action='store_true',
+        help='Suppress report output if pylint fails')
+    parser.add_argument(
         '--version',
         action='store_true',
         help='Print current version number')
@@ -55,7 +59,7 @@ def main():
         sys.exit(0)
 
     result = commit_hook.check_repo(
-        args.limit, args.pylint, args.pylintrc, args.pylint_params)
+        args.limit, args.pylint, args.pylintrc, args.pylint_params, args.suppress_report)
 
     if result:
         sys.exit(0)

--- a/git_pylint_commit_hook/commit_hook.py
+++ b/git_pylint_commit_hook/commit_hook.py
@@ -82,7 +82,8 @@ def _parse_score(pylint_output):
 
 
 def check_repo(
-        limit, pylint='pylint', pylintrc='.pylintrc', pylint_params=None):
+        limit, pylint='pylint', pylintrc='.pylintrc', pylint_params=None,
+        suppress_report=False):
     """ Main function doing the checks
 
     :type limit: float
@@ -93,6 +94,8 @@ def check_repo(
     :param pylintrc: Path to pylintrc file
     :type pylint_params: str
     :param pylint_params: Custom pylint parameters to add to the pylint command
+    :type suppress_report: bool
+    :param suppress_report: Suppress report if score is below limit
     """
     # List of checked files and their results
     python_files = []
@@ -175,6 +178,13 @@ def check_repo(
         # Add some output
         print('{:.2}/10.00\t{}'.format(decimal.Decimal(score), status))
         if 'FAILED' in status:
+            if suppress_report:
+                command.append('--reports=n')
+                proc = subprocess.Popen(
+                    command,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE)
+                out, _ = proc.communicate()
             print out
 
 


### PR DESCRIPTION
I found the pylint reports to be a bit much when I failed pylint checks. I took the liberty of adding in an option to suppress them. It's a bit crude since it just runs pylint again with reports disabled, but it was seemingly the simplest way.