### PR TITLE
Use pylint to find pylintrc by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - "2.7"
-install: pip install nose2
+install: pip install pylint nose2
 before_script:
   - git config --global user.email "you@example.com"
   - git config --global user.name "Your Name"

--- a/git-pylint-commit-hook
+++ b/git-pylint-commit-hook
@@ -37,10 +37,10 @@ def main():
         help='Path to pylint executable. Default: pylint')
     parser.add_argument(
         '--pylintrc',
-        default='.pylintrc',
         help=(
             'Path to pylintrc file. Options in the pylintrc will '
-            'override the command line parameters. Default: .pylintrc'))
+            'override the command line parameters. Default: pylint'
+            'search order'))
     parser.add_argument(
         '--pylint-params',
         help='Custom pylint parameters to add to the pylint command')

--- a/git_pylint_commit_hook/commit_hook.py
+++ b/git_pylint_commit_hook/commit_hook.py
@@ -7,6 +7,9 @@ import subprocess
 import collections
 import ConfigParser
 
+# Avoid collision with other things called 'pylint'
+import pylint.config as pylint_config
+
 
 ExecutionResult = collections.namedtuple(
     'ExecutionResult',
@@ -82,7 +85,7 @@ def _parse_score(pylint_output):
 
 
 def check_repo(
-        limit, pylint='pylint', pylintrc='.pylintrc', pylint_params=None,
+        limit, pylint='pylint', pylintrc=None, pylint_params=None,
         suppress_report=False):
     """ Main function doing the checks
 
@@ -97,6 +100,10 @@ def check_repo(
     :type suppress_report: bool
     :param suppress_report: Suppress report if score is below limit
     """
+    if pylintrc is None:
+        # If no config is found, use the old default '.pylintrc'
+        pylintrc = pylint_config.find_pylintrc() or '.pylintrc'
+
     # List of checked files and their results
     python_files = []
 


### PR DESCRIPTION
The commit hook defaults to using '.pylintrc' as the name of the config file, but pylint itself has a more complicated search order. This change uses `pylint.config.find_pylintrc()` to find the same config that pylint itself would use.