### PR TITLE
Add a way to specify files to ignore

### DIFF
--- a/git-pylint-commit-hook
+++ b/git-pylint-commit-hook
@@ -52,6 +52,10 @@ def main():
         '--version',
         action='store_true',
         help='Print current version number')
+    parser.add_argument(
+        '--ignore', dest='ignored_files', action='append',
+        default=[], help='Add regex to blacklist files or directories, '
+        'allowing to avoid running pylint those files.')
     args = parser.parse_args()
 
     if args.version:
@@ -59,7 +63,8 @@ def main():
         sys.exit(0)
 
     result = commit_hook.check_repo(
-        args.limit, args.pylint, args.pylintrc, args.pylint_params, args.suppress_report)
+        args.limit, args.pylint, args.pylintrc, args.pylint_params,
+        args.suppress_report, args.ignored_files)
 
     if result:
         sys.exit(0)

--- a/git_pylint_commit_hook/commit_hook.py
+++ b/git_pylint_commit_hook/commit_hook.py
@@ -68,6 +68,14 @@ def _is_python_file(filename):
         return 'python' in first_line and '#!' in first_line
 
 
+def _is_blacklisted(filename, blacklist):
+    for black_regex in blacklist:
+        if re.findall(black_regex, filename):
+            return True
+
+    return False
+
+
 _SCORE_REGEXP = re.compile(
     r'^Your\ code\ has\ been\ rated\ at\ (\-?[0-9\.]+)/10')
 
@@ -87,7 +95,7 @@ def _parse_score(pylint_output):
 
 def check_repo(
         limit, pylint='pylint', pylintrc='.pylintrc', pylint_params=None,
-        suppress_report=False):
+        suppress_report=False, ignored_files=[]):
     """ Main function doing the checks
 
     :type limit: float
@@ -110,7 +118,8 @@ def check_repo(
     # Find Python files
     for filename in _get_list_of_committed_files():
         try:
-            if _is_python_file(filename):
+            if _is_python_file(filename) and not _is_blacklisted(filename,
+                                                                 ignored_files):
                 python_files.append((filename, None))
         except IOError:
             print('File not found (probably deleted): {}\t\tSKIPPED'.format(


### PR DESCRIPTION
This way we can iteratively pylint files in a big project ensuring that no pylint regression happens meanwhile.