### PR TITLE
Default to empty strings to be able to concatenate them

### DIFF
--- a/git-pylint-commit-hook
+++ b/git-pylint-commit-hook
@@ -43,6 +43,7 @@ def main():
             'override the command line parameters. Default: .pylintrc'))
     parser.add_argument(
         '--pylint-params',
+        default='',
         help='Custom pylint parameters to add to the pylint command')
     parser.add_argument(
         '--suppress-report',

--- a/git_pylint_commit_hook/commit_hook.py
+++ b/git_pylint_commit_hook/commit_hook.py
@@ -131,7 +131,7 @@ def _stash_unstaged():
 
 
 def check_repo(
-        limit, pylint='pylint', pylintrc='.pylintrc', pylint_params=None,
+        limit, pylint='pylint', pylintrc='.pylintrc', pylint_params='',
         suppress_report=False):
     """ Main function doing the checks
 


### PR DESCRIPTION
If the argument pylint_params is None as default and it is not defined on the arguments of the hook, but on the .pylintrc of the current dir, it fails to concatenate None and a string.