### PR TITLE
Support for showing pylint violations in case of passing of limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ var
 sdist
 develop-eggs
 .installed.cfg
+.idea
 
 # Installer logs
 pip-log.txt

--- a/git-pylint-commit-hook
+++ b/git-pylint-commit-hook
@@ -12,7 +12,7 @@ LICENSE:
     http://www.apache.org/licenses/LICENSE-2.0.html
 """
 
-VERSION = '2.1.1'
+VERSION = '2.1.2'
 
 import argparse
 import sys
@@ -49,6 +49,10 @@ def main():
         action='store_true',
         help='Suppress report output if pylint fails')
     parser.add_argument(
+        '--always-show-violations',
+        action='store_true',
+        help='Show violations in case of pass as well')
+    parser.add_argument(
         '--version',
         action='store_true',
         help='Print current version number')
@@ -59,7 +63,7 @@ def main():
         sys.exit(0)
 
     result = commit_hook.check_repo(
-        args.limit, args.pylint, args.pylintrc, args.pylint_params, args.suppress_report)
+        args.limit, args.pylint, args.pylintrc, args.pylint_params, args.suppress_report, args.always_show_violations)
 
     if result:
         sys.exit(0)

--- a/git_pylint_commit_hook/commit_hook.py
+++ b/git_pylint_commit_hook/commit_hook.py
@@ -221,7 +221,11 @@ def check_repo(
 
             # Verify the score
             score = _parse_score(out)
-            status, all_filed_passed = ('PASSED', True) if score >= float(limit) else ('FAILED', False)
+            if score >= float(limit):
+                status = 'PASSED'
+            else:
+                status = 'FAILED'
+                all_filed_passed = False
 
             # Add some output
             print('{:.2}/10.00\t{}'.format(decimal.Decimal(score), status))

--- a/git_pylint_commit_hook/settings.conf
+++ b/git_pylint_commit_hook/settings.conf
@@ -1,2 +1,2 @@
 [general]
-version: 2.1.1
+version: 2.1.2

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='git-pylint-commit-hook',
-    version='2.1.1',
+    version='2.1.2',
     license='Apache License, Version 2.0',
     description='Git commit hook that checks Python files with pylint',
     author='Sebastian Dahlgren',


### PR DESCRIPTION
The changes made induce a new parameter to the command to allow viewing pylint violations in case when the file score is high enough within limit.