### PR TITLE
Make stashing optional

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -39,6 +39,9 @@ The ``git-pylint-commit-hook`` can be configured using command line options. The
       --ignore IGNORED_FILES
                             Add regex to blacklist files or directories, allowing
                             to avoid running pylint those files.
+      --stash               Stash any unstaged changes while linting (changes are
+                            unstashed automatically unless the process is forcibly
+                            killed)
 
 You can simply append those to the command created in the **Basic configuration** above.
 

--- a/git-pylint-commit-hook
+++ b/git-pylint-commit-hook
@@ -64,6 +64,12 @@ def main():
         help=(
             'Add regex to blacklist files or directories, '
             'allowing to avoid running pylint those files.'))
+    parser.add_argument(
+        '--stash',
+        action='store_true',
+        help='Stash any unstaged changes while linting '
+             '(changes are unstashed automatically '
+             'unless the process is forcibly killed) ')
     args = parser.parse_args()
 
     if args.version:
@@ -77,7 +83,8 @@ def main():
         args.pylint_params,
         args.suppress_report,
         args.always_show_violations,
-        args.ignored_files)
+        args.ignored_files,
+        args.stash)
 
 if __name__ == '__main__':
     result = main()

--- a/git_pylint_commit_hook/commit_hook.py
+++ b/git_pylint_commit_hook/commit_hook.py
@@ -136,7 +136,9 @@ def _stash_unstaged():
     # so that the user can work out what happened and fix things manually
     subprocess.check_call('git stash save -q --keep-index '
                           'git-pylint-commit-hook'.split())
-    new_stash = _current_stash()
+    stashed = original_stash != _current_stash()
+    if stashed:
+        print('Unstaged changes were detected and stashed')
 
     try:
         # let the caller do whatever they wanted to do
@@ -144,11 +146,18 @@ def _stash_unstaged():
         yield
     finally:
         # only restore if we actually stashed something
-        if original_stash != new_stash:
+        if stashed:
+            print('Restoring stashed changes')
             # avoid merge issues
             subprocess.check_call('git reset --hard -q'.split())
             # restore everything to how it was
             subprocess.check_call('git stash pop --index -q'.split())
+
+
+@contextlib.contextmanager
+def _noop():
+    """A context manager that does nothing."""
+    yield
 
 
 def _is_ignored(filename, ignored_paths):
@@ -170,7 +179,8 @@ def _is_ignored(filename, ignored_paths):
 
 def check_repo(
         limit, pylint='pylint', pylintrc=None, pylint_params='',
-        suppress_report=False, always_show_violations=False, ignored_files=None):
+        suppress_report=False, always_show_violations=False,
+        ignored_files=None, stash=False):
     """ Main function doing the checks
 
     :type limit: float
@@ -187,6 +197,8 @@ def check_repo(
     :param always_show_violations: Show violations in case of pass as well
     :type ignored_files: list
     :param ignored_files: List of files to exclude from the validation
+    :type stash: bool
+    :param stash: Stash any unstaged changes while linting
     """
     # Lists are mutable and should not be assigned in function arguments
     if ignored_files is None:
@@ -202,8 +214,13 @@ def check_repo(
         # If no config is found, use the old default '.pylintrc'
         pylintrc = pylint_config.find_pylintrc() or '.pylintrc'
 
-    # Stash any unstaged changes while we look at the tree
-    with _stash_unstaged():
+    if stash:
+        maybe_stash_unstaged = _stash_unstaged
+    else:
+        maybe_stash_unstaged = _noop
+
+    # Optionally stash any unstaged changes while we look at the tree
+    with maybe_stash_unstaged():
         # Find Python files
         for filename in _get_list_of_committed_files():
             try:


### PR DESCRIPTION
If the process is forcibly killed, the changes will not be unstashed,
and the user will have to pop them manually. This change requires
the user to opt-in so they know what is happening.