### PR TITLE
Fixed the pylint ignored file problem with version 1.7.x

### DIFF
--- a/git_pylint_commit_hook/commit_hook.py
+++ b/git_pylint_commit_hook/commit_hook.py
@@ -99,7 +99,7 @@ def _parse_score(pylint_output):
 
 
 _IGNORE_REGEXT = re.compile(
-    r'Ignoring entire file \(file\-ignored\)'
+    r'(Ignoring entire file \(file\-ignored\))|(^0 statements analysed.)'
 )
 
 

--- a/tests.py
+++ b/tests.py
@@ -195,3 +195,17 @@ class TestHook(unittest.TestCase):
         self.assertTrue(commit_hook._check_ignore(text))
         text = 'Your code has been rated at 8.51'
         self.assertFalse(commit_hook._check_ignore(text))
+        text = '''Report
+======
+0 statements analysed.
+
+Statistics by type
+------------------'''
+        self.assertTrue(commit_hook._check_ignore(text))
+        text = '''Report
+======
+100 statements analysed.
+
+Statistics by type
+------------------'''
+        self.assertFalse(commit_hook._check_ignore(text))


### PR DESCRIPTION
Because the pylint new version remove the `Ignoring entire file (file-ignored)` mark.