### PR TITLE
Don't fail files with pylint: skip-file

### DIFF
--- a/git_pylint_commit_hook/commit_hook.py
+++ b/git_pylint_commit_hook/commit_hook.py
@@ -274,7 +274,7 @@ def check_repo(
                             command.append('--rcfile={}'.format(pylintrc))
                 else:
                     if pylintrc:
-                       command.append('--rcfile={}'.format(pylintrc))
+                        command.append('--rcfile={}'.format(pylintrc))
 
                 command.append(python_file)
                 proc = subprocess.Popen(
@@ -292,6 +292,9 @@ def check_repo(
             ignored = _check_ignore(out)
             if ignored or score >= float(limit):
                 status = 'PASSED'
+            elif not out and not proc.returncode:
+                # pylint produced no output but also no errors
+                status = 'SKIPPED'
             else:
                 status = 'FAILED'
                 all_filed_passed = False


### PR DESCRIPTION
When pylint completely skips a file (e.g. with `# pylint: skip-file`),
there is no score output for that file because there is no output from
pylint at all.

The previous code considered this to be a failure because _parse_score
returns 0.0 if the score regex is not matched.

This code checks for cases where pylint produces no output and its
return code is 0, indicating that it intentionally skipped the
file. This commit introduces a new status of 'SKIPPED', which does not
cause the commit to be stopped.

----

The overall effect of this change is to make it less necessary to rely on the --ignore command line option, since pylint itself provides a syntax for situations where it isn't necessary to check a file.

I also fixed a very small indentation style issue which pylint itself was complaining to me about. :)