### PR TITLE
setup.py: Use URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description='Git commit hook that checks Python files with pylint',
     author='Sebastian Dahlgren',
     author_email='sebastian.dahlgren@gmail.com',
-    url='http://www.sebastiandahlgren.se',
+    url='https://github.com/sebdah/git-pylint-commit-hook',
     keywords="git commit pre-commit hook pylint python",
     platforms=['Any'],
     packages=['git_pylint_commit_hook'],


### PR DESCRIPTION
The current URL on PyPI doesnt have information about the project.