### PR TITLE
Add version requirements to ``setup.py``

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'pylint',
+        'pylint<2.7',
         'future'
     ],
     classifiers=[
@@ -26,4 +26,5 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python'
     ]
+    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <=3.6',
 )


### PR DESCRIPTION
Prompted by an issue raised against `pylint` itself: https://github.com/PyCQA/pylint/issues/6821

This makes it so ``setup.py`` reflects what's in the README and will warn users who try to use an incompatible version with this package.